### PR TITLE
Remove deployment url id from ui template

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({}) => {
-  const deploymentId = process.env.LLAMA_DEPLOY_DEPLOYMENT_URL_ID;
+  const deploymentName = process.env.LLAMA_DEPLOY_DEPLOYMENT_NAME;
   const basePath = process.env.LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH;
   const projectId = process.env.LLAMA_DEPLOY_PROJECT_ID;
   const port = process.env.PORT;
@@ -30,9 +30,9 @@ export default defineConfig(({}) => {
     define: {
       // Copy through some standard environment variables to make
       // integration with workflows api easier
-      ...(deploymentId && {
+      ...(deploymentName && {
         "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME":
-          JSON.stringify(deploymentId),
+          JSON.stringify(deploymentName),
       }),
       ...(basePath && {
         "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH":


### PR DESCRIPTION
Remove `LLAMA_DEPLOY_DEPLOYMENT_URL_ID` from the UI template to exclusively use `LLAMA_DEPLOY_DEPLOYMENT_NAME`, as `URL_ID`'s backward compatibility was only for the server library.

---
Linear Issue: [LI-3589](https://linear.app/llamaindex/issue/LI-3589/rename-llama-deploy-deployment-url-id-to-llama-deploy-deployment-name)

<a href="https://cursor.com/background-agent?bcId=bc-aed8bfb0-a579-49c5-a0a1-6a4de2c0e33c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aed8bfb0-a579-49c5-a0a1-6a4de2c0e33c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

